### PR TITLE
1.21.6 Port

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.12
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
+loader_version=0.16.13
 
 # Mod Properties
-mod_version=2.7.0+1.21.5
+mod_version=2.7.0+1.21.6
 maven_group=de.dafuqs
 archives_base_name=paginatedadvancements
 
 # Dependencies
-fabric_api_version=0.119.9+1.21.5
-cloth_config_version=18.0.145
-modmenu_version=14.0.0-rc.2
+fabric_api_version=0.128.2+1.21.6
+cloth_config_version=19.0.147
+modmenu_version=15.0.0-beta.3

--- a/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementScreen.java
+++ b/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementScreen.java
@@ -3,10 +3,10 @@ package de.dafuqs.paginatedadvancements.client;
 import com.google.common.collect.*;
 import de.dafuqs.paginatedadvancements.*;
 import net.minecraft.advancement.*;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.*;
 import net.minecraft.client.gui.screen.advancement.*;
 import net.minecraft.client.network.*;
-import net.minecraft.client.render.*;
 import net.minecraft.client.util.*;
 import net.minecraft.text.*;
 import net.minecraft.util.*;
@@ -108,21 +108,21 @@ public class PaginatedAdvancementScreen extends AdvancementsScreen implements Cl
 		if (this.selectedTab != null && PaginatedAdvancementsClient.CONFIG.PinningEnabled) {
 			if (isClickOnFavouritesButton(mouseX, mouseY, startY, endX)) {
 				if (PaginatedAdvancementsClient.isPinned(this.selectedTab.getRoot().getAdvancementEntry().id())) {
-					context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, FAVOURITES_BUTTON_WIDTH, 46 + FAVOURITES_BUTTON_HEIGHT, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
+					context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, FAVOURITES_BUTTON_WIDTH, 46 + FAVOURITES_BUTTON_HEIGHT, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
 				} else {
-					context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, 0, 46 + FAVOURITES_BUTTON_HEIGHT, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
+					context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, 0, 46 + FAVOURITES_BUTTON_HEIGHT, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
 				}
 			} else {
 				if (PaginatedAdvancementsClient.isPinned(this.selectedTab.getRoot().getAdvancementEntry().id())) {
-					context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, FAVOURITES_BUTTON_WIDTH, 46, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
+					context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, FAVOURITES_BUTTON_WIDTH, 46, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
 				} else {
-					context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, 0, 46, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
+					context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, endX - FAVOURITES_BUTTON_OFFSET_X, startY + FAVOURITES_BUTTON_OFFSET_Y, 0, 46, FAVOURITES_BUTTON_WIDTH, FAVOURITES_BUTTON_HEIGHT, 256, 256);
 				}
 			}
 			
 			if(hasPins) {
 				// draw pinned tab header
-				context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, endX + PinnedAdvancementTabType.getTabX() + 1, startY + 6, 46, 0, 32, 15, 256, 256);
+				context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, endX + PinnedAdvancementTabType.getTabX() + 1, startY + 6, 46, 0, 32, 15, 256, 256);
 			}
 		}
 	}
@@ -216,18 +216,18 @@ public class PaginatedAdvancementScreen extends AdvancementsScreen implements Cl
 	public void drawPaginationButtons(DrawContext context, int mouseX, int mouseY, int startX, int endX) {
 		if (isClickOnBackTab(mouseX, mouseY, startX, endX)) {
 			// hover
-			context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 0, 23, 23, 23, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 0, 23, 23, 23, 256, 256);
 		} else {
 			// no hover
-			context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 0, 0, 23, 23, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 0, 0, 23, 23, 256, 256);
 		}
 		
 		if (isClickOnForwardTab(mouseX, mouseY, startX, endX)) {
 			// hover
-			context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, endX - startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 23, 23, 23, 23, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, endX - startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 23, 23, 23, 23, 256, 256);
 		} else {
 			// no hover
-			context.drawTexture(RenderLayer::getGuiTextured, PAGINATION_TEXTURE, endX - startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 23, 0, 23, 23, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PAGINATION_TEXTURE, endX - startX + 4, TOP_ELEMENT_HEIGHT + ADDITIONAL_PADDING_TOP - 15, 23, 0, 23, 23, 256, 256);
 		}
 	}
 	
@@ -245,10 +245,10 @@ public class PaginatedAdvancementScreen extends AdvancementsScreen implements Cl
 	
 	private void drawFrame(DrawContext context, int startX, int startY, int endX, int endY) {
 		// corners
-		context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, startX, startY, 0, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top left
-		context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, endX - ELEMENT_WIDTH, startY, 237, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top right
-		context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, startX, endY - BOTTOM_ELEMENT_HEIGHT, 0, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom left
-		context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, endX - ELEMENT_WIDTH, endY - BOTTOM_ELEMENT_HEIGHT, 237, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom right
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, startX, startY, 0, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top left
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, endX - ELEMENT_WIDTH, startY, 237, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top right
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, startX, endY - BOTTOM_ELEMENT_HEIGHT, 0, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom left
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, endX - ELEMENT_WIDTH, endY - BOTTOM_ELEMENT_HEIGHT, 237, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom right
 		
 		// left + right sides
 		int maxTopHeightInOneDrawCall = 100;
@@ -257,8 +257,8 @@ public class PaginatedAdvancementScreen extends AdvancementsScreen implements Cl
 		while (middleHeight > 0) {
 			int currentDrawHeight = Math.min(middleHeight, maxTopHeightInOneDrawCall);
 			
-			context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, startX, currentY, 0, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
-			context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, endX - ELEMENT_WIDTH, currentY, 237, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, startX, currentY, 0, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, endX - ELEMENT_WIDTH, currentY, 237, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
 			
 			middleHeight -= currentDrawHeight;
 			currentY += currentDrawHeight;
@@ -271,8 +271,8 @@ public class PaginatedAdvancementScreen extends AdvancementsScreen implements Cl
 		while (middleWidth > 0) {
 			int currentDrawWidth = Math.min(middleWidth, maxTopWidthInOneDrawCall);
 			
-			context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, currentX, startY, ELEMENT_WIDTH, 0, currentDrawWidth, TOP_ELEMENT_HEIGHT, 256, 256);
-			context.drawTexture(RenderLayer::getGuiTextured, WINDOW_TEXTURE, currentX, endY - BOTTOM_ELEMENT_HEIGHT, ELEMENT_WIDTH, 125, currentDrawWidth, BOTTOM_ELEMENT_HEIGHT, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, currentX, startY, ELEMENT_WIDTH, 0, currentDrawWidth, TOP_ELEMENT_HEIGHT, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, WINDOW_TEXTURE, currentX, endY - BOTTOM_ELEMENT_HEIGHT, ELEMENT_WIDTH, 125, currentDrawWidth, BOTTOM_ELEMENT_HEIGHT, 256, 256);
 			
 			middleWidth -= currentDrawWidth;
 			currentX += currentDrawWidth;
@@ -460,16 +460,16 @@ public class PaginatedAdvancementScreen extends AdvancementsScreen implements Cl
 	
 	private void drawWidgetTooltip(DrawContext context, int mouseX, int mouseY, int startX, int startY, int endXTitle, int endXWindow, int endY) {
 		if (this.selectedTab != null) {
-			context.getMatrices().push();
-			context.getMatrices().translate((startX + 9), (startY + 18), 400.0D);
+			context.getMatrices().pushMatrix();
+			context.getMatrices().translate((startX + 9), (startY + 18));//, 400.0D);
 			this.selectedTab.drawWidgetTooltip(context, mouseX - startX - 9, mouseY - startY - 18, startX, startY, endXWindow, endY);
 			
-			context.getMatrices().translate(0, 0, 400.0D);
+			context.getMatrices().translate(0, 0);//, 400.0D);
 			if (PaginatedAdvancementsClient.CONFIG.shouldShowAdvancementDebug(this.client)) {
 				this.selectedTab.drawDebugInfo(context, startX, startY, endXWindow, endY);
 			}
 			
-			context.getMatrices().pop();
+			context.getMatrices().popMatrix();
 		}
 		
 		if (this.tabs.size() > 1) {
@@ -503,7 +503,6 @@ public class PaginatedAdvancementScreen extends AdvancementsScreen implements Cl
 		
 		clampCurrentPage(startX, endXTitle, endXWindow); // if the screen has been resized
 		
-		this.renderBackground(context, mouseX, mouseY, delta);
 		this.drawAdvancementTree(context, startX, startY, endXWindow, endY);
 		this.drawWindow(context, mouseX, mouseY, startX, startY, endXWindow, endY);
 		

--- a/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementTab.java
+++ b/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementTab.java
@@ -5,9 +5,9 @@ import de.dafuqs.paginatedadvancements.*;
 import de.dafuqs.paginatedadvancements.mixin.*;
 import net.minecraft.advancement.*;
 import net.minecraft.client.*;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.*;
 import net.minecraft.client.gui.screen.advancement.*;
-import net.minecraft.client.render.*;
 import net.minecraft.client.texture.*;
 import net.minecraft.item.*;
 import net.minecraft.text.*;
@@ -111,8 +111,8 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 		}
 		
 		context.enableScissor(startX, startY, advancementTreeWindowWidth, advancementTreeWindowHeight);
-		context.getMatrices().push();
-		context.getMatrices().translate(startX, startY, 0.0F);
+		context.getMatrices().pushMatrix();
+		context.getMatrices().translate(startX, startY);
 		Identifier identifier = this.display.getBackground().map(AssetInfo::texturePath).orElse(TextureManager.MISSING_IDENTIFIER);
 
 		int i = MathHelper.floor(this.originX);
@@ -124,7 +124,7 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 		int textureCountY = (advancementTreeWindowHeight) / 16 + 2;
 		for (int m = -1; m < textureCountX; ++m) {
 			for (int n = -1; n < textureCountY; ++n) {
-				context.drawTexture(RenderLayer::getGuiTextured, identifier, k + 16 * m, l + 16 * n, 0.0F, 0.0F, 16, 16, 16, 16);
+				context.drawTexture(RenderPipelines.GUI_TEXTURED, identifier, k + 16 * m, l + 16 * n, 0.0F, 0.0F, 16, 16, 16, 16);
 			}
 		}
 		
@@ -132,13 +132,13 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 		this.rootWidget.renderLines(context, i, j, false);
 		this.rootWidget.renderWidgets(context, i, j);
 		
-		context.getMatrices().pop();
+		context.getMatrices().popMatrix();
 		context.disableScissor();
 	}
 	
 	public void drawWidgetTooltip(DrawContext context, int mouseX, int mouseY, int startX, int startY, int endXWindow, int endY) {
-		context.getMatrices().push();
-		context.getMatrices().translate(0.0F, 0.0F, -200.0F);
+		context.getMatrices().pushMatrix();
+		context.getMatrices().translate(0.0F, 0.0F);
 		
 		// tinting the background slightly darker
 		// (this is the vanilla default, but able to be disabled via config)
@@ -162,7 +162,7 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 			}
 		}
 		
-		context.getMatrices().pop();
+		context.getMatrices().popMatrix();
 		if (hoversWidget) {
 			this.alpha = MathHelper.clamp(this.alpha + 0.02F, 0.0F, 0.3F);
 		} else {
@@ -200,7 +200,7 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 			int requirementY = startY + 15;
 			if (PaginatedAdvancementsClient.CONFIG.ShowAdvancementIDInDebugTooltip) {
 				Text idText = Text.literal("ID: " + advancementWidgetAccessor.getAdvancement().getAdvancementEntry().id().toString() + " ").append(Text.translatable("text.paginated_advancements.copy_to_clipboard"));
-				context.drawText(this.client.textRenderer, idText, startX + 5, startY + 5, 0xFFFFFF, true);
+				context.drawText(this.client.textRenderer, idText, startX + 5, startY + 5, 0xFF_FFFFFF, true);
 			} else {
 				requirementY = startY + 5;
 			}
@@ -263,15 +263,15 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 	}
 	
 	protected void drawDebugFrame(DrawContext context, int startX, int startY, int endX, int endY) {
-		context.getMatrices().push();
+		context.getMatrices().pushMatrix();
 		
 		int TOP_ELEMENT_HEIGHT = 15;
 		
 		// corners
-		context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, startX, startY, 0, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top left
-		context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, endX - ELEMENT_WIDTH, startY, 237, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top right
-		context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, startX, endY - BOTTOM_ELEMENT_HEIGHT, 0, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom left
-		context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, endX - ELEMENT_WIDTH, endY - BOTTOM_ELEMENT_HEIGHT, 237, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom right
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, startX, startY, 0, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top left
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, endX - ELEMENT_WIDTH, startY, 237, 0, ELEMENT_WIDTH, TOP_ELEMENT_HEIGHT, 256, 256); // top right
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, startX, endY - BOTTOM_ELEMENT_HEIGHT, 0, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom left
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, endX - ELEMENT_WIDTH, endY - BOTTOM_ELEMENT_HEIGHT, 237, 125, ELEMENT_WIDTH, BOTTOM_ELEMENT_HEIGHT, 256, 256); // bottom right
 		
 		// left + right sides
 		int maxTopHeightInOneDrawCall = 100;
@@ -280,8 +280,8 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 		while (middleHeight > 0) {
 			int currentDrawHeight = Math.min(middleHeight, maxTopHeightInOneDrawCall);
 			
-			context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, startX, currentY, 0, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
-			context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, endX - ELEMENT_WIDTH, currentY, 237, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, startX, currentY, 0, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, endX - ELEMENT_WIDTH, currentY, 237, TOP_ELEMENT_HEIGHT, ELEMENT_WIDTH, currentDrawHeight, 256, 256);
 			
 			middleHeight -= currentDrawHeight;
 			currentY += currentDrawHeight;
@@ -294,8 +294,8 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 		while (middleWidth > 0) {
 			int currentDrawWidth = Math.min(middleWidth, maxTopWidthInOneDrawCall);
 			
-			context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, currentX, startY, ELEMENT_WIDTH, 0, currentDrawWidth, TOP_ELEMENT_HEIGHT, 256, 256);
-			context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, currentX, endY - BOTTOM_ELEMENT_HEIGHT, ELEMENT_WIDTH, 125, currentDrawWidth, BOTTOM_ELEMENT_HEIGHT, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, currentX, startY, ELEMENT_WIDTH, 0, currentDrawWidth, TOP_ELEMENT_HEIGHT, 256, 256);
+			context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, currentX, endY - BOTTOM_ELEMENT_HEIGHT, ELEMENT_WIDTH, 125, currentDrawWidth, BOTTOM_ELEMENT_HEIGHT, 256, 256);
 			
 			middleWidth -= currentDrawWidth;
 			currentX += currentDrawWidth;
@@ -315,7 +315,7 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 			int drawWidth = centerEndX - centerStartX;
 			while (drawWidth > 0) {
 				int currentWidth = Math.min(200, drawWidth);
-				context.drawTexture(RenderLayer::getGuiTextured, PaginatedAdvancementScreen.WINDOW_TEXTURE, drawStartX, drawStartY, 4, 4, currentWidth, currentHeight, 256, 256);
+				context.drawTexture(RenderPipelines.GUI_TEXTURED, PaginatedAdvancementScreen.WINDOW_TEXTURE, drawStartX, drawStartY, 4, 4, currentWidth, currentHeight, 256, 256);
 				drawWidth -= currentWidth;
 				drawStartX += currentWidth;
 			}
@@ -323,15 +323,15 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 			drawStartY += currentHeight;
 		}
 		
-		context.getMatrices().pop();
+		context.getMatrices().popMatrix();
 	}
 	
 	protected void drawRequirementsWithOverflow(DrawContext context, int startX, int startY, int endX, int endY, List<MutableText> requirements, int lines) {
 		for (int i = 0; i < lines; i++) {
 			if (i == lines - 1) {
-				context.drawText(this.client.textRenderer, Text.translatable("text.paginated_advancements.expand_debug"), startX, startY, 0x999999, false);
+				context.drawText(this.client.textRenderer, Text.translatable("text.paginated_advancements.expand_debug"), startX, startY, 0xff999999, false);
 			} else {
-				context.drawText(this.client.textRenderer, requirements.get(i), startX, startY, 0x00ff00, false);
+				context.drawText(this.client.textRenderer, requirements.get(i), startX, startY, 0xff00ff00, false);
 			}
 			startY += 10;
 		}
@@ -349,17 +349,17 @@ public class PaginatedAdvancementTab extends AdvancementTab {
 		}
 		
 		if (scrollAmount > 0) {
-			context.drawText(this.client.textRenderer, Text.translatable("text.paginated_advancements.scroll_debug"), startX, startY, 0x999999, false);
+			context.drawText(this.client.textRenderer, Text.translatable("text.paginated_advancements.scroll_debug"), startX, startY, 0xff_999999, false);
 			scrollAmount += 1;
 			startY += 10;
 		}
 		for (int i = scrollAmount; i < requirements.size(); i++) {
 			if (startY + 10 >= endY) break;
 			else if (startY + 20 >= endY && i + 1 != requirements.size()) {
-				context.drawText(this.client.textRenderer, Text.translatable("text.paginated_advancements.scroll_debug"), startX, startY, 0x999999, false);
+				context.drawText(this.client.textRenderer, Text.translatable("text.paginated_advancements.scroll_debug"), startX, startY, 0xff_999999, false);
 				break;
 			}
-			context.drawText(this.client.textRenderer, requirements.get(i), startX, startY, 0x00ff00, false);
+			context.drawText(this.client.textRenderer, requirements.get(i), startX, startY, 0xff_00ff00, false);
 			startY += 10;
 		}
 	}

--- a/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementTabType.java
+++ b/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementTabType.java
@@ -1,8 +1,8 @@
 package de.dafuqs.paginatedadvancements.client;
 
 import de.dafuqs.paginatedadvancements.*;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.*;
-import net.minecraft.client.render.*;
 import net.minecraft.item.*;
 import net.minecraft.util.*;
 
@@ -27,7 +27,7 @@ public class PaginatedAdvancementTabType {
 		} else {
 			identifier = selected ? TOP_MIDDLE_TEXTURE_SELECTED : TOP_MIDDLE_TEXTURE;
 		}
-		context.drawGuiTexture(RenderLayer::getGuiTextured, identifier, x + getTabX(index), y + getTabY(), WIDTH, HEIGHT);
+		context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, identifier, x + getTabX(index), y + getTabY(), WIDTH, HEIGHT);
 	}
 	
 	public static void drawIcon(DrawContext context, int x, int y, int index, ItemStack stack) {

--- a/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementWidget.java
+++ b/src/main/java/de/dafuqs/paginatedadvancements/client/PaginatedAdvancementWidget.java
@@ -6,9 +6,9 @@ import net.fabricmc.api.*;
 import net.minecraft.advancement.*;
 import net.minecraft.client.*;
 import net.minecraft.client.font.*;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.*;
 import net.minecraft.client.gui.screen.advancement.*;
-import net.minecraft.client.render.*;
 import net.minecraft.text.*;
 import net.minecraft.util.*;
 import net.minecraft.util.math.*;
@@ -66,10 +66,10 @@ public class PaginatedAdvancementWidget extends AdvancementWidget {
 			Identifier advancementID = accessor.getAdvancement().getAdvancementEntry().id();
 			@Nullable FrameWrapper frameWrapper = AdvancementFrameDataLoader.get(advancementID);
 			if (frameWrapper != null) {
-				context.drawGuiTexture(RenderLayer::getGuiTextured, frameWrapper.getTexture(advancementObtainedStatus, accessor.getDisplay().getFrame()), x + accessor.getX() + 3, y + accessor.getY(), 26, 26);
+				context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, frameWrapper.getTexture(advancementObtainedStatus, accessor.getDisplay().getFrame()), x + accessor.getX() + 3, y + accessor.getY(), 26, 26);
 				context.drawItemWithoutEntity(accessor.getDisplay().getIcon(), x + accessor.getX() + 8 + frameWrapper.getItemOffsetX(), y + accessor.getY() + 5 + frameWrapper.getItemOffsetY());
 			} else {
-				context.drawGuiTexture(RenderLayer::getGuiTextured, advancementObtainedStatus.getFrameTexture(accessor.getDisplay().getFrame()), x + accessor.getX() + 3, y + accessor.getY(), 26, 26);
+				context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, advancementObtainedStatus.getFrameTexture(accessor.getDisplay().getFrame()), x + accessor.getX() + 3, y + accessor.getY(), 26, 26);
 				context.drawItemWithoutEntity(accessor.getDisplay().getIcon(), x + accessor.getX() + 8, y + accessor.getY() + 5);
 			}
 		}
@@ -131,19 +131,19 @@ public class PaginatedAdvancementWidget extends AdvancementWidget {
 		int n = 32 + this.description.size() * 9;
 		if (!this.description.isEmpty()) {
 			if (bl2) {
-				context.drawGuiTexture(RenderLayer::getGuiTextured, TITLE_BOX_TEXTURE, startX, l + 26 - n, accessor.getWidth(), n);
+				context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TITLE_BOX_TEXTURE, startX, l + 26 - n, accessor.getWidth(), n);
 			} else {
-				context.drawGuiTexture(RenderLayer::getGuiTextured, TITLE_BOX_TEXTURE, startX, l, accessor.getWidth(), n);
+				context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, TITLE_BOX_TEXTURE, startX, l, accessor.getWidth(), n);
 			}
 		}
 		
-		context.drawGuiTexture(RenderLayer::getGuiTextured, advancementObtainedStatus.getBoxTexture(), 200, 26, 0, 0, startX, l, j, 26);
-		context.drawGuiTexture(RenderLayer::getGuiTextured, advancementObtainedStatus2.getBoxTexture(), 200, 26, 200 - k, 0, startX + j, l, k, 26);
+		context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, advancementObtainedStatus.getBoxTexture(), 200, 26, 0, 0, startX, l, j, 26);
+		context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, advancementObtainedStatus2.getBoxTexture(), 200, 26, 200 - k, 0, startX + j, l, k, 26);
 		
 		if (this.frameWrapper != null) {
-			context.drawGuiTexture(RenderLayer::getGuiTextured, this.frameWrapper.getTexture(advancementObtainedStatus3, accessor.getDisplay().getFrame()), originX + accessor.getX() + 3, originY + accessor.getY(), 26, 26);
+			context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, this.frameWrapper.getTexture(advancementObtainedStatus3, accessor.getDisplay().getFrame()), originX + accessor.getX() + 3, originY + accessor.getY(), 26, 26);
 		} else {
-			context.drawGuiTexture(RenderLayer::getGuiTextured, advancementObtainedStatus3.getFrameTexture(accessor.getDisplay().getFrame()), originX + accessor.getX() + 3, originY + accessor.getY(), 26, 26);
+			context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, advancementObtainedStatus3.getFrameTexture(accessor.getDisplay().getFrame()), originX + accessor.getX() + 3, originY + accessor.getY(), 26, 26);
 		}
 		
 		if (shouldRenderToTheLeft) {

--- a/src/main/java/de/dafuqs/paginatedadvancements/client/PinnedAdvancementTabType.java
+++ b/src/main/java/de/dafuqs/paginatedadvancements/client/PinnedAdvancementTabType.java
@@ -1,9 +1,9 @@
 package de.dafuqs.paginatedadvancements.client;
 
 import de.dafuqs.paginatedadvancements.*;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.*;
 import net.minecraft.client.gui.screen.advancement.*;
-import net.minecraft.client.render.*;
 import net.minecraft.item.*;
 import net.minecraft.util.*;
 
@@ -29,7 +29,7 @@ public class PinnedAdvancementTabType {
 		} else {
 			identifier = selected ? RIGHT_MIDDLE_TEXTURE_SELECTED : RIGHT_MIDDLE_TEXTURE;
 		}
-		context.drawGuiTexture(RenderLayer::getGuiTextured, identifier, x + getTabX(), y + getTabY(index), WIDTH, HEIGHT);
+		context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, identifier, x + getTabX(), y + getTabY(index), WIDTH, HEIGHT);
 		
 		AdvancementTabType.RIGHT.drawBackground(context, x + getTabX(), y + getTabY(index), selected, index);
 	}


### PR DESCRIPTION
1.21.6 port.
Main changes are:
- Render layers have been replaced with RenderPipelines
- Text now uses ARBG so it needs 0xff before it
- `DrawContext.matricies` is now 2d so there is no more `transform(x, y, z)`